### PR TITLE
Create compatibility with IERC721 and IERC5192

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,4 +1,4 @@
-[default]
+[profile.default]
 src = 'src'
 out = 'out'
 libs = ['lib']

--- a/sdk/test/index_test.mjs
+++ b/sdk/test/index_test.mjs
@@ -24,11 +24,11 @@ test("generating a compact signature for function give", async (t) => {
     name: "Name",
     version: "Version",
     chainId: 31337, // the chainId of foundry
-    verifyingContract: "0xce71065d4017f316ec606fe4422e11eb2c47c246",
+    verifyingContract: "0x5615deb798bb3e4dfa0139dfa1b3d433cc23b72f",
   };
 
   const agreement = {
-    active: "0xb4c79dab8f259c7aee6e5b2aa729821864227e84",
+    active: "0x7fa9385be102ac3eac297483dd6233d62b3e1496",
     passive: passiveAddress,
     metadata: utils.toUtf8Bytes("https://example.com/metadata.json"),
   };
@@ -38,6 +38,6 @@ test("generating a compact signature for function give", async (t) => {
   t.is(signature.length, 64 + 64 + 2 + 2);
   t.is(
     signature,
-    "0x4473afdec84287f10aa0b5eb608d360e2e9220bee657a4a5ca468e69a4de255c38691fca0c52f295d1831beaa0b7f079c1ab7959257578d2fb8d98740d9b0e111c"
+    "0x0e1183b212232b4f1c3e11edd00059fb01710c0335b81c11a43d11d5b7cd01d55483b1a1432f76c4d3cab1bb2607622fd173f8f3d6bdbe8927c4706f9be447321b"
   );
 });

--- a/src/ERC4973.sol
+++ b/src/ERC4973.sol
@@ -70,14 +70,14 @@ abstract contract ERC4973 is
     ERC721(name, symbol)
   {}
 
-  function _burn(uint256 tokenId) internal override (ERC721, ERC721URIStorage) {
+  function _burn(uint256 tokenId) internal override(ERC721, ERC721URIStorage) {
     super._burn(tokenId);
   }
 
   function tokenURI(uint256 tokenId)
     public
     view
-    override (ERC721, ERC721URIStorage)
+    override(ERC721, ERC721URIStorage)
     returns (string memory)
   {
     return super.tokenURI(tokenId);
@@ -155,11 +155,7 @@ abstract contract ERC4973 is
     address passive,
     bytes calldata metadata,
     bytes calldata signature
-  )
-    internal
-    virtual
-    returns (uint256)
-  {
+  ) internal virtual returns (uint256) {
     bytes32 hash = _getHash(active, passive, metadata);
     uint256 tokenId = uint256(hash);
 
@@ -176,8 +172,9 @@ abstract contract ERC4973 is
     view
     returns (bytes32)
   {
-    bytes32 structHash =
-      keccak256(abi.encode(AGREEMENT_HASH, active, passive, keccak256(metadata)));
+    bytes32 structHash = keccak256(
+      abi.encode(AGREEMENT_HASH, active, passive, keccak256(metadata))
+    );
     return _hashTypedDataV4(structHash);
   }
 }

--- a/src/ERC4973.sol
+++ b/src/ERC4973.sol
@@ -34,6 +34,24 @@ abstract contract ERC4973 is
     _;
   }
 
+  function safeTransferFrom(address, address, uint256, bytes memory)
+    public
+    override
+    notSupported
+  {}
+
+  function safeTransferFrom(address, address, uint256)
+    public
+    override
+    notSupported
+  {}
+
+  function transferFrom(address, address, uint256) public override notSupported {}
+
+  function approve(address, uint256) public override notSupported {}
+
+  function setApprovalForAll(address, bool) public override notSupported {}
+
   function getApproved(uint256) public pure override returns (address) {
     return address(0x0);
   }
@@ -46,24 +64,6 @@ abstract contract ERC4973 is
   {
     return false;
   }
-
-  function approve(address, uint256) public override notSupported {}
-
-  function setApprovalForAll(address, bool) public override notSupported {}
-
-  function transferFrom(address, address, uint256) public override notSupported {}
-
-  function safeTransferFrom(address, address, uint256)
-    public
-    override
-    notSupported
-  {}
-
-  function safeTransferFrom(address, address, uint256, bytes memory)
-    public
-    override
-    notSupported
-  {}
 
   constructor(string memory name, string memory symbol, string memory version)
     EIP712(name, version)
@@ -83,9 +83,13 @@ abstract contract ERC4973 is
     return super.tokenURI(tokenId);
   }
 
-  function locked(uint256 tokenId) external view returns (bool) {
+  function _locked(uint256 tokenId) internal view returns (bool) {
     require(_exists(tokenId), "locked: tokenId doesn't exist");
     return true;
+  }
+
+  function locked(uint256 tokenId) external view returns (bool) {
+    return _locked(tokenId);
   }
 
   function supportsInterface(bytes4 interfaceId)

--- a/src/ERC4973.t.sol
+++ b/src/ERC4973.t.sol
@@ -233,6 +233,44 @@ contract ERC4973Test is Test, ERC721Holder {
     abt.take(from, bytes(tokenURI), signature);
   }
 
+  function testGiveEmits() public {
+    address from = address(this);
+    address to = address(approver);
+    bytes memory metadata = bytes(tokenURI);
+    bytes32 hash = abt.getHash(from, to, metadata);
+    uint256 tokenId = uint256(hash);
+    bytes memory signature;
+
+    vm.expectEmit(true, true, true, false, address(abt));
+    emit Transfer(address(0), address(this), tokenId);
+    emit Transfer(address(this), to, tokenId);
+    emit Locked(tokenId);
+    abt.give(to, metadata, signature);
+
+    assertEq(abt.balanceOf(to), 1);
+    assertEq(abt.tokenURI(tokenId), tokenURI);
+    assertEq(abt.ownerOf(tokenId), to);
+  }
+
+  function testTakeEmits() public {
+    address to = address(this);
+    address from = address(approver);
+    bytes memory metadata = bytes(tokenURI);
+    bytes32 hash = abt.getHash(to, from, metadata);
+    uint256 tokenId = uint256(hash);
+    bytes memory signature;
+
+    vm.expectEmit(true, true, true, false, address(abt));
+    emit Transfer(address(0), from, tokenId);
+    emit Transfer(from, to, tokenId);
+    emit Locked(tokenId);
+    abt.take(from, metadata, signature);
+
+    assertEq(abt.balanceOf(to), 1);
+    assertEq(abt.tokenURI(tokenId), tokenURI);
+    assertEq(abt.ownerOf(tokenId), to);
+  }
+
   function testGiveWithApprovingERC1271Contract() public {
     address to = address(approver);
     bytes memory signature;

--- a/src/ERC4973.t.sol
+++ b/src/ERC4973.t.sol
@@ -42,11 +42,7 @@ contract AccountAbstraction is ERC1271Mock {
     address to,
     bytes calldata metadata,
     bytes calldata signature
-  )
-    external
-    virtual
-    returns (uint256)
-  {
+  ) external virtual returns (uint256) {
     return ERC4973(collection).give(to, metadata, signature);
   }
 
@@ -55,11 +51,7 @@ contract AccountAbstraction is ERC1271Mock {
     address from,
     bytes calldata metadata,
     bytes calldata signature
-  )
-    external
-    virtual
-    returns (uint256)
-  {
+  ) external virtual returns (uint256) {
     return ERC4973(collection).take(from, metadata, signature);
   }
 

--- a/src/ERC4973.t.sol
+++ b/src/ERC4973.t.sol
@@ -345,8 +345,13 @@ contract ERC4973Test is Test, ERC721Holder {
     bytes32 hash = abt.getHash(from, to, bytes(tokenURI));
     (uint8 v, bytes32 r, bytes32 s) = vm.sign(passivePrivateKey, hash);
     bytes memory signature = abi.encodePacked(r, s, v);
+    // NOTE: This hex signature value may go out of sync at one point with the
+    // SDK.  Don't panic then! The most likely reason is that e.g. the `address
+    // from` which is this test contract, or the verifying address in the
+    // EIP-712 set up have changed! So check them, update the code and see if
+    // you can establish lock step again!
     bytes memory expected =
-      hex"4473afdec84287f10aa0b5eb608d360e2e9220bee657a4a5ca468e69a4de255c38691fca0c52f295d1831beaa0b7f079c1ab7959257578d2fb8d98740d9b0e111c";
+      hex"0e1183b212232b4f1c3e11edd00059fb01710c0335b81c11a43d11d5b7cd01d55483b1a1432f76c4d3cab1bb2607622fd173f8f3d6bdbe8927c4706f9be447321b";
     assertEq(signature, expected);
 
     uint256 tokenId = abt.give(to, bytes(tokenURI), signature);
@@ -396,8 +401,13 @@ contract ERC4973Test is Test, ERC721Holder {
     bytes32 hash = abt.getHash(to, passiveAddress, bytes(tokenURI));
     (uint8 v, bytes32 r, bytes32 s) = vm.sign(passivePrivateKey, hash);
     bytes memory signature = abi.encodePacked(r, s, v);
+    // NOTE: This hex signature value may go out of sync at one point with the
+    // SDK.  Don't panic then! The most likely reason is that e.g. the `address
+    // from` which is this test contract, or the verifying address in the
+    // EIP-712 set up have changed! So check them, update the code and see if
+    // you can establish lock step again!
     bytes memory expected =
-      hex"4473afdec84287f10aa0b5eb608d360e2e9220bee657a4a5ca468e69a4de255c38691fca0c52f295d1831beaa0b7f079c1ab7959257578d2fb8d98740d9b0e111c";
+      hex"0e1183b212232b4f1c3e11edd00059fb01710c0335b81c11a43d11d5b7cd01d55483b1a1432f76c4d3cab1bb2607622fd173f8f3d6bdbe8927c4706f9be447321b";
     assertEq(signature, expected);
 
     uint256 tokenId = abt.take(passiveAddress, bytes(tokenURI), signature);

--- a/src/ERC4973.t.sol
+++ b/src/ERC4973.t.sol
@@ -115,6 +115,36 @@ contract ERC4973Test is Test, ERC721Holder {
     aa = new AccountAbstraction(true);
   }
 
+  function testBlockingERC721AccordingToERC5192() public {
+    address from = address(0);
+    address to = address(this);
+    uint256 tokenId = 0;
+
+    vm.expectEmit(true, true, true, false);
+    emit Transfer(from, to, tokenId);
+    abt.mint(to, tokenId);
+
+    bytes memory data;
+    vm.expectRevert(bytes("notSupported: Soulbound NFT EIP-5192"));
+    abt.safeTransferFrom(address(this), address(1), tokenId, data);
+
+    vm.expectRevert(bytes("notSupported: Soulbound NFT EIP-5192"));
+    abt.safeTransferFrom(address(this), address(1), tokenId);
+
+    vm.expectRevert(bytes("notSupported: Soulbound NFT EIP-5192"));
+    abt.transferFrom(address(this), address(1), tokenId);
+
+    vm.expectRevert(bytes("notSupported: Soulbound NFT EIP-5192"));
+    abt.approve(address(1), tokenId);
+
+    vm.expectRevert(bytes("notSupported: Soulbound NFT EIP-5192"));
+    abt.setApprovalForAll(address(1), true);
+
+    assertEq(address(0), abt.getApproved(tokenId));
+
+    assertFalse(abt.isApprovedForAll(address(this), address(0)));
+  }
+
   function testIERC721() public {
     assertTrue(abt.supportsInterface(type(IERC721).interfaceId));
   }

--- a/src/interfaces/IERC4973.sol
+++ b/src/interfaces/IERC4973.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.6;
 /// @title Account-bound tokens
 /// @dev See https://eips.ethereum.org/EIPS/eip-4973
 /// Note: the ERC-165 identifier for this interface is 0xf8801853.
-interface IERC4973 /* is IERC721, IERC721Metadata */ {
+interface IERC4973 { /* is IERC721, IERC721Metadata */
   /// @notice Removes the `uint256 tokenId` from an account. At any time, an
   ///  ABT receiver must be able to disassociate themselves from an ABT
   ///  publicly through calling this function. After successfully executing this

--- a/src/interfaces/IERC5192.sol
+++ b/src/interfaces/IERC5192.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.0;
+
+interface IERC5192 {
+  /// @notice Emitted when the locking status is changed to locked.
+  /// @dev If a token is minted and the status is locked, this event should be emitted.
+  /// @param tokenId The identifier for a token.
+  event Locked(uint256 tokenId);
+
+  /// @notice Emitted when the locking status is changed to unlocked.
+  /// @dev If a token is minted and the status is unlocked, this event should be emitted.
+  /// @param tokenId The identifier for a token.
+  event Unlocked(uint256 tokenId);
+
+  /// @notice Returns the locking status of an Soulbound Token
+  /// @dev SBTs assigned to zero address are considered invalid, and queries
+  /// about them do throw.
+  /// @param tokenId The identifier for an SBT.
+  function locked(uint256 tokenId) external view returns (bool);
+}


### PR DESCRIPTION
Summary:

- Integrates EIP-721 and EIP-5192 into EIP-4973.
- All transfer-related external EIP-721 functions are disabled according to the EIP-5192 specification: https://github.com/attestate/ERC4973/blob/9c641d4282b69c1e9ab6f6c1b9d73c4d1e529d1a/src/ERC4973.sol#L32-L66 and then we're also testing if they're all throwing: https://github.com/attestate/ERC4973/blob/9c641d4282b69c1e9ab6f6c1b9d73c4d1e529d1a/src/ERC4973.t.sol#L118-L146
- We implement `function locked` of EIP5192: https://github.com/attestate/ERC4973/blob/9c641d4282b69c1e9ab6f6c1b9d73c4d1e529d1a/src/ERC4973.sol#L86-L93
- `event Locked(tokenId)` are emitted upon completion of give and take. But honestly I'm not sure how I feel about it. Maybe we should keep it unopinionated and later provide a "afterTransfer" hook like OZ does that allows the developer to call this function themselves.
- In both `function give` and `take`, we now make use of OpenZeppelin's internal mint and transfer functionality of their ERC721 abstract contract: https://github.com/attestate/ERC4973/blob/9c641d4282b69c1e9ab6f6c1b9d73c4d1e529d1a/src/ERC4973.sol#L121-L123
- Any mint transfer is now NOT anymore between the issuer and the receiver, as in `emit Transfer(issuer, receiver, tokenId)`. Instead, we're now first minting the NFT from address zero to the issuer `emit Transfer(0, issuer, tokenId)` and then we're immediately transferring the token to the receiver from the issuer `emit Transfer(issuer, receiver, tokenId)`. This is to enable EIP-721 compatibility and I think this might also fix an issue downstream: https://github.com/otterspace-xyz/badges-subgraph/issues/13
- Most accounting logic has now been replaced with OpenZeppelin's ERC721 logic.
